### PR TITLE
Fixed main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "type": "git",
     "url": "git://github.com/benmarch/angular-bootstrap-tour.git"
   },
-  "main": "angular-bootstrap-tour.js",
+  "main": "dist/angular-bootstrap-tour.js",
   "scripts": {
     "test": "grunt"
   },


### PR DESCRIPTION
The file `angular-bootstrap-tour.js` does not exist. `dist/angular-bootstrap-tour.js` however does.